### PR TITLE
Fix: Fixed schemas to add AAT support (fixes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
         "_isEnabled": true,
         "title": "Definition",
         "body": "{{{word}}}: {{{definition}}}",
-        "confirmText": "Close",
         "_showIcon": true
     }
 ```
@@ -24,7 +23,6 @@
         "_isEnabled": true,
         "title": "Definition",
         "body": "{{{word}}}: {{{definition}}}",
-        "confirmText": "Close",
         "_showIcon": true,
         "_items": [
             {
@@ -53,6 +51,6 @@
                 "definition": "Excellent word this one"
             }
         ]
-    } 
+    }
 ```
 

--- a/example.json
+++ b/example.json
@@ -3,7 +3,6 @@
         "_isEnabled": true,
         "title": "Definition",
         "body": "{{{word}}}: {{{definition}}}",
-        "confirmText": "Close",
         "_showIcon": true,
         "_items": [
             {

--- a/js/adapt-definitions.js
+++ b/js/adapt-definitions.js
@@ -67,11 +67,6 @@ class Definitions extends Backbone.Controller {
     notify.popup({
       title,
       body: '<div no-definition="true">' + body + '</div>',
-      _prompts: [
-        {
-          promptText: this.model.get('confirmText') || 'Close'
-        }
-      ],
       _showIcon: this.model.get('_showIcon'),
       _classes: 'is-extension is-definitions'
     });

--- a/properties.schema
+++ b/properties.schema
@@ -2,13 +2,88 @@
   "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
+  "required": false,
   "properties": {
     "pluginLocations": {
       "type": "object",
+      "required": true,
       "properties": {
-        "config": {
+        "course": {
           "type": "object",
-          "properties": {}
+          "properties": {
+            "_definitions": {
+              "type": "object",
+              "required": false,
+              "legend": "Definitions",
+              "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "required": true,
+                  "default": false,
+                  "title": "Add definition links to course words",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Controls whether the Definitions extension is enabled or disabled."
+                },
+                "title": {
+                  "type": "string",
+                  "default": "Definition",
+                  "required": true,
+                  "title": "Title",
+                  "inputType": "Text",
+                  "validators": ["required"],
+                  "help": "The title for the pop up which displays when a definitions link is selected.",
+                  "translatable": true
+                },
+                "body": {
+                  "type": "string",
+                  "default": "{{{word}}}: {{{definition}}}",
+                  "required": false,
+                  "title": "Body",
+                  "inputType": "Text",
+                  "validators": [],
+                  "help": "The body content for the pop up which displays when a definitions link is selected.",
+                  "translatable": true
+                },
+                "_items": {
+                  "type": "array",
+                  "required": true,
+                  "title": "Items",
+                  "items": {
+                    "type": "object",
+                    "required": false,
+                    "properties": {
+                      "_words": {
+                        "type": "array",
+                        "required": false,
+                        "title": "Words",
+                        "items": {
+                          "type": "string",
+                          "required": false,
+                          "default": "",
+                          "title": "Word",
+                          "inputType": "Text",
+                          "validators": [],
+                          "help": "The collection of word(s) to attach the associated definition to.",
+                          "translatable": true
+                        }
+                      },
+                      "definition": {
+                        "type": "string",
+                        "default": "",
+                        "required": false,
+                        "title": "Definition",
+                        "inputType": "Text",
+                        "validators": [],
+                        "help": "The definition for the associated word(s).",
+                        "translatable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -1,0 +1,74 @@
+{
+  "$anchor": "definitions-course",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "$patch": {
+    "source": {
+      "$ref": "course"
+    },
+    "with": {
+      "properties": {
+        "_definitions": {
+          "type": "object",
+          "title": "Definitions",
+          "default": {},
+          "required": [
+            "title"
+          ],
+          "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "title": "Add definition links to course words",
+              "description": "Controls whether the Definitions extension is enabled or disabled.",
+              "default": false
+            },
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "default": "Definition",
+              "description": "The title for the pop up which displays when a definitions link is selected.",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "body": {
+              "type": "string",
+              "title": "Body",
+              "default": "{{{word}}}: {{{definition}}}",
+              "description": "The body content for the pop up which displays when a definitions link is selected.",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "_items": {
+              "type": "array",
+              "title": "Items",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "_words": {
+                    "type": "array",
+                    "title": "Words",
+                    "description": "The collection of word(s) to attach the associated definition to.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "definition": {
+                    "type": "string",
+                    "title": "Definition",
+                    "default": "",
+                    "description": "The definition for the associated word(s).",
+                    "_adapt": {
+                      "translatable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes: #12 

### Fix
* Updated old and new schemas to allow for plugin import into AAT
* Removed `confirmText` references as it is not supported in notify
