### PR TITLE
Fix: Guard against missing definitions config (fixes #23)

### DIFF
--- a/js/Injector.js
+++ b/js/Injector.js
@@ -14,6 +14,7 @@ class Injector extends Backbone.Controller {
   }
 
   onLoaded() {
+    if (!Adapt.definitions?._table) return;
     this.processDocument();
     this.startWatching();
   }


### PR DESCRIPTION
Fixes #23

### Fix
* Guard against missing `_definitions` configuration in `Injector.onLoaded()` to prevent `TypeError` when `_table` is undefined

### Testing
1. Remove `_definitions` from course.json entirely - course should load without errors
2. Set `_isEnabled: false` - course should load without errors
3. Set `_items` to empty array - course should load without errors
4. Configure definitions normally - verify definitions still work as expected

Posted via collaboration with Claude Code